### PR TITLE
Use persistent cache for temp reglists instead of tempdir()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ URL: http://natverse.org/nat.templatebrains/,
     https://github.com/natverse/nat.templatebrains
 Depends:
     nat (>= 1.8.6),
-    R (>= 2.10),
+    R (>= 4.0),
     rgl
 Imports:
     digest,

--- a/R/reg_repos.R
+++ b/R/reg_repos.R
@@ -113,6 +113,22 @@ add_reg_folders<-function(dir=extra_reg_folders(), first=TRUE) {
 }
 
 
+# Clean up session folders where the original tempdir no longer exists
+# (indicating the R session has ended)
+cleanup_stale_reglist_sessions <- function(cache_base) {
+  if (!dir.exists(cache_base)) return()
+  session_dirs <- list.dirs(cache_base, recursive = FALSE, full.names = TRUE)
+  for (d in session_dirs) {
+    marker <- file.path(d, ".tempdir_path")
+    if (file.exists(marker)) {
+      original_tempdir <- readLines(marker, n = 1, warn = FALSE)
+      if (!dir.exists(original_tempdir)) {
+        unlink(d, recursive = TRUE)
+      }
+    }
+  }
+}
+
 #' Add reglist object describing a bridging/mirroring registration
 #'
 #' @description By specifying either \code{reference, sample} \emph{or}
@@ -126,8 +142,8 @@ add_reg_folders<-function(dir=extra_reg_folders(), first=TRUE) {
 #' @param mirror The reference brain (in \code{character} or
 #'   \code{templatebrain} form) for a mirroring registration.
 #' @param temp Whether to store the on disk representation in a session-specific
-#'   temporary folder (that will be removed when R closes). Defaults to
-#'   \code{TRUE}.
+#'   cache folder. These are cleaned up when a new session detects that the
+#'   original session has ended. Defaults to \code{TRUE}.
 #' @param ... Additional arguments passed to \code{\link{saveRDS}} e.g. to
 #'   control compression when the reglist object is saved to disk.
 #' @return This function is called for its side effect and has no return value.
@@ -149,12 +165,22 @@ add_reglist <- function(x, reference=NULL, sample=NULL, mirror=NULL, temp=TRUE,
                         ...) {
   # first make a place to store the registration
   if(temp){
-    d <- file.path(tempdir(), 'nat.templatebrains', 'tempreglists')
+    # Use persistent cache with session-specific subfolder
+    # (tempdir() itself gets cleaned by macOS after 3 days of inactivity)
+    cache_base <- file.path(tools::R_user_dir("nat.templatebrains", "cache"), "tempreglists")
+    cleanup_stale_reglist_sessions(cache_base)
+    d <- file.path(cache_base, basename(tempdir()))
   } else {
     d <- file.path(local_reg_dir_for_url(), "reglists")
   }
   if(!file.exists(d))
     dir.create(d, recursive = TRUE)
+  # Write marker file to track which tempdir this session uses
+  if(temp) {
+    marker <- file.path(d, ".tempdir_path")
+    if(!file.exists(marker))
+      writeLines(tempdir(), marker)
+  }
   add_reg_folders(d <- normalizePath(d), first = TRUE)
 
   # now save it with an appropriate name


### PR DESCRIPTION
## Summary

- macOS cleans up `tempdir()` files after 3 days of inactivity, causing compound registrations saved with `add_reglist(temp=TRUE)` to disappear during long-running R sessions
- Changed to use `tools::R_user_dir("nat.templatebrains", "cache")` with session-specific subfolders
- Each session gets its own folder named after `basename(tempdir())` (e.g., `RtmpeWpUOg`)
- A `.tempdir_path` marker file tracks the original tempdir, and stale session folders are cleaned up when a new session detects the original tempdir no longer exists
- This bumps the minimum R version to 4.0

## How it works

1. On `add_reglist(temp=TRUE)`, files go to `~/.../cache/nat.templatebrains/tempreglists/RtmpXXXXX/`
2. A `.tempdir_path` marker stores the full original `tempdir()` path
3. On subsequent calls, `cleanup_stale_reglist_sessions()` checks each session folder's marker
4. If the original tempdir no longer exists, that session has ended and its folder is removed

## Test plan

- [ ] Verify session-specific folders are created in cache location
- [ ] Verify `.tempdir_path` marker is written
- [ ] Verify stale session folders are cleaned up when original tempdir is gone
- [ ] Verify malecns bridging registrations persist during long sessions

🤖 Generated with [Claude Code](https://claude.ai/code)