### PR TITLE
Use in-memory cache for temporary reglists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Depends:
     R (>= 2.10),
     rgl
 Imports:
+    cachem,
     digest,
     igraph,
     memoise,

--- a/R/reg_repos.R
+++ b/R/reg_repos.R
@@ -1,3 +1,25 @@
+# In-memory cache for temporary reglists (avoids tempdir cleanup issues on macOS)
+.reglist_cache <- cachem::cache_mem()
+
+# Get a reglist from the in-memory cache
+# @param key The cache key (e.g., "FAFB14_FlyWire" or "JFRC2_mirror")
+# @return The unserialized reglist object, or NULL if not found
+get_cached_reglist <- function(key) {
+  val <- .reglist_cache$get(key)
+  if (is.null(val)) return(NULL)
+  unserialize(val)
+}
+
+# List all keys in the in-memory reglist cache
+list_cached_reglists <- function() {
+  .reglist_cache$keys()
+}
+
+# Clear the in-memory reglist cache (mainly for testing)
+clear_reglist_cache <- function() {
+  .reglist_cache$reset()
+}
+
 #' Download and register git repository containing registrations
 #'
 #' Note that these extra registrations will be downloaded to a standard location
@@ -125,11 +147,12 @@ add_reg_folders<-function(dir=extra_reg_folders(), first=TRUE) {
 #'   or \code{templatebrain} form) for a bridging registration.
 #' @param mirror The reference brain (in \code{character} or
 #'   \code{templatebrain} form) for a mirroring registration.
-#' @param temp Whether to store the on disk representation in a session-specific
-#'   temporary folder (that will be removed when R closes). Defaults to
-#'   \code{TRUE}.
-#' @param ... Additional arguments passed to \code{\link{saveRDS}} e.g. to
-#'   control compression when the reglist object is saved to disk.
+#' @param temp Whether to store in an in-memory cache (default \code{TRUE}) or
+#'   persist to disk (\code{FALSE}). In-memory storage serializes the reglist
+#'   to break environment references, avoiding memory leaks from captured
+#'   closures.
+#' @param ... Additional arguments passed to \code{\link{saveRDS}} when
+#'   \code{temp=FALSE}.
 #' @return This function is called for its side effect and has no return value.
 #' @export
 #' @seealso add_reg_folders
@@ -147,24 +170,31 @@ add_reg_folders<-function(dir=extra_reg_folders(), first=TRUE) {
 #' }
 add_reglist <- function(x, reference=NULL, sample=NULL, mirror=NULL, temp=TRUE,
                         ...) {
-  # first make a place to store the registration
-  if(temp){
-    d <- file.path(tempdir(), 'nat.templatebrains', 'tempreglists')
+  # Determine the key/filename
+  if(!is.null(mirror)) {
+    key <- paste0(as.character(mirror), "_mirror")
+  } else if(is.null(reference) || is.null(sample)) {
+    stop("Must supply reference and sample brains to define a bridging registration")
   } else {
-    d <- file.path(local_reg_dir_for_url(), "reglists")
+    key <- paste0(as.character(reference), "_", as.character(sample))
   }
+
+  if(temp) {
+    # Store serialized reglist in memory cache
+    # Serialization breaks environment references, avoiding memory leaks
+    .reglist_cache$set(key, serialize(x, NULL))
+    reset_cache()
+    return(invisible())
+  }
+
+  # For temp=FALSE, persist to disk
+  d <- file.path(local_reg_dir_for_url(), "reglists")
   if(!file.exists(d))
     dir.create(d, recursive = TRUE)
   add_reg_folders(d <- normalizePath(d), first = TRUE)
 
-  # now save it with an appropriate name
-  if(!is.null(mirror)) {
-    f=paste0(as.character(mirror), "_mirror.rds")
-  } else if(is.null(reference) || is.null(sample)) {
-    stop("Must supply reference and sample brains to define a bridging registration")
-  } else {
-    f=paste0(as.character(reference), "_", as.character(sample), ".rds")
-  }
+  # Save with appropriate name (key already computed above)
+  f <- paste0(key, ".rds")
   saveRDS(x, file=file.path(d, f), ...)
   reset_cache()
   return(invisible())

--- a/R/transformation.R
+++ b/R/transformation.R
@@ -66,7 +66,14 @@ simplify_bridging_sequence<-function(x) {
   # convert all elements of x to reglists ...
   make_reglist <- function(r) {
     swap=NULL
-    if(is.character(r) && tools::file_ext(r)=="rds"){
+    if(is.character(r) && startsWith(r, "memory://")) {
+      # In-memory cached reglist
+      swap=attr(r, 'swap')
+      key <- sub("^memory://", "", r)
+      r <- get_cached_reglist(key)
+      if(is.null(r))
+        stop("Cached reglist not found: ", key)
+    } else if(is.character(r) && tools::file_ext(r)=="rds"){
       swap=attr(r, 'swap')
       r=readRDS(r)
     }
@@ -147,9 +154,19 @@ allreg_dataframe<-function(regdirs=getOption('nat.templatebrains.regdirs')) {
   if(!length(regdirs)) regdirs=character()
   df=data.frame(path=dir(regdirs, pattern = '\\.(list|rds)$', full.names = T),
                 stringsAsFactors = F)
+
+  # Add in-memory cached reglists with memory:// prefix
+  mem_keys <- list_cached_reglists()
+  if(length(mem_keys) > 0) {
+    mem_df <- data.frame(path = paste0("memory://", mem_keys),
+                         stringsAsFactors = FALSE)
+    df <- rbind(df, mem_df)
+  }
+
   df$name=basename(df$path)
   df$dup=duplicated(df$name)
-  df$bridge=!grepl("(mirror|imgflip)\\.list",df$name)
+  # Non-bridging regs end with _mirror or _imgflip, optionally followed by extension
+  df$bridge=!grepl("(mirror|imgflip)(\\.[^.]+)?$",df$name)
   df$reference=gsub("^([^_]+)_.*","\\1", df$name)
   df$sample=gsub("^[^_]+_([^.]+).*","\\1", df$name)
   # set mirroring registration sample brain to NA

--- a/tests/testthat/test-transformation.r
+++ b/tests/testthat/test-transformation.r
@@ -84,6 +84,8 @@ context("Bridging Graph")
 test_that("bridging graph and friends work",{
   skip_on_cran()
 
+  # Clear in-memory cache to test empty state
+  nat.templatebrains:::clear_reglist_cache()
   expect_is(emptydf<-allreg_dataframe(NULL), 'data.frame')
   expect_equal(nrow(emptydf), 0L)
 
@@ -183,6 +185,9 @@ context("Transformation")
 test_that("can use a bridging registration in regdirs",{
   if(is.null(cmtk.bindir()))
     skip("skipping transformation tests since CMTK is not installed")
+
+  # Clear in-memory cache for clean test environment
+  nat.templatebrains:::clear_reglist_cache()
 
   td=tempfile(pattern = 'extrabridge')
   dir.create(td)


### PR DESCRIPTION
## Summary

Replaces disk-based storage in `tempdir()` with in-memory caching via `cachem::cache_mem()`. This avoids macOS tempdir cleanup issues during long-running R sessions.

## Background

macOS cleans up files in `tempdir()` after 3 days of inactivity. For long-running R sessions (>3 days), this causes compound reglists saved with `add_reglist(temp=TRUE)` to disappear, breaking bridging registrations.

## Approach

Instead of writing to disk, we:
1. Serialize the reglist (breaking environment references to avoid memory leaks)
2. Store the serialized bytes in `cachem::cache_mem()`
3. Use `memory://` prefix in paths to identify in-memory entries
4. Modify `allreg_dataframe()` and `make_reglist()` to handle memory-backed entries

## Benefits

- **CRAN compliant** - no file system writes for `temp=TRUE`
- **No tempdir issues** - works on all platforms, survives cleanup
- **Memory safe** - serialization breaks closure environment references
- **Simple** - uses existing `cachem` dependency (via `memoise`)

## Alternative approach

See PR #53 for a disk-based approach using `tools::R_user_dir()`. This PR supersedes that approach as it avoids CRAN policy concerns about writing to user directories.

## Test plan

- [x] All existing tests pass
- [ ] Manual testing with malecns bridging registrations

🤖 Generated with [Claude Code](https://claude.ai/code)