### PR TITLE
Fix bridge/mirror misclassification for in-memory reglists

### DIFF
--- a/R/reg_repos.R
+++ b/R/reg_repos.R
@@ -1,6 +1,8 @@
 # In-memory cache for temporary reglists (avoids tempdir cleanup issues on macOS)
 # Using a simple environment since cachem has key restrictions (lowercase only)
 .reglist_cache <- new.env(parent = emptyenv())
+# Tracks whether each cached entry is a mirror (TRUE) or bridge (FALSE) registration
+.reglist_mirror_cache <- new.env(parent = emptyenv())
 
 # Get a reglist from the in-memory cache
 # @param key The cache key (e.g., "FAFB14_FlyWire" or "JFRC2_mirror")
@@ -16,9 +18,16 @@ list_cached_reglists <- function() {
   ls(.reglist_cache)
 }
 
+# Return logical vector: is each key a mirror registration?
+# @param keys character vector of cache keys
+is_cached_mirror <- function(keys) {
+  vapply(keys, function(k) isTRUE(.reglist_mirror_cache[[k]]), logical(1))
+}
+
 # Clear the in-memory reglist cache (mainly for testing)
 clear_reglist_cache <- function() {
   rm(list = ls(.reglist_cache), envir = .reglist_cache)
+  rm(list = ls(.reglist_mirror_cache), envir = .reglist_mirror_cache)
 }
 
 #' Download and register git repository containing registrations
@@ -184,6 +193,7 @@ add_reglist <- function(x, reference=NULL, sample=NULL, mirror=NULL, temp=TRUE,
     # Store serialized reglist in memory cache
     # Serialization breaks environment references, avoiding memory leaks
     .reglist_cache[[key]] <- serialize(x, NULL)
+    .reglist_mirror_cache[[key]] <- !is.null(mirror)
     reset_cache()
     return(invisible())
   }

--- a/R/transformation.R
+++ b/R/transformation.R
@@ -165,8 +165,14 @@ allreg_dataframe<-function(regdirs=getOption('nat.templatebrains.regdirs')) {
 
   df$name=basename(df$path)
   df$dup=duplicated(df$name)
-  # Non-bridging regs end with _mirror or _imgflip, optionally followed by extension
-  df$bridge=!grepl("(mirror|imgflip)(\\.[^.]+)?$",df$name)
+  # Non-bridging regs end with _mirror or _imgflip followed by a file extension
+  df$bridge=!grepl("(mirror|imgflip)\\.[^.]+$",df$name)
+  # For memory entries, use the stored type rather than guessing from the name,
+  # since a bridging reg's sample brain name may legitimately end with "_mirror"
+  if(length(mem_keys) > 0) {
+    mem_is_mirror <- is_cached_mirror(mem_keys)
+    df$bridge[df$path %in% paste0("memory://", mem_keys)] <- !mem_is_mirror
+  }
   df$reference=gsub("^([^_]+)_.*","\\1", df$name)
   df$sample=gsub("^[^_]+_([^.]+).*","\\1", df$name)
   # set mirroring registration sample brain to NA

--- a/tests/testthat/test-transformation.r
+++ b/tests/testthat/test-transformation.r
@@ -46,6 +46,12 @@ test_that("we can work with reglist objects on disk",{
                xform(pts, solve(m)))
 
   expect_error(add_reglist(sample='rhubarb'), "reference and sample")
+
+  # Regression test: bridging reg where sample brain name ends with "_mirror"
+  # should not be misclassified as a mirror registration
+  add_reglist(reglist(m1, m2), reference = "rhubarb", sample="crumble_mirror")
+  df <- nat.templatebrains:::allreg_dataframe()
+  expect_true(df$bridge[df$name == "rhubarb_crumble_mirror"])
 })
 
 test_that("we can find bridging registrations",{


### PR DESCRIPTION
## Summary

- Bridge registrations whose sample brain name contains `_mirror` (e.g. `JFRC2013_mirror`) were being incorrectly classified as mirror registrations when stored in the in-memory reglist cache
- The bug was introduced when the memcache was added: `allreg_dataframe()` re-used the filename-based regex `(mirror|imgflip)(\\.[^.]+)?$` to classify cache keys, which matched `JFRC2_JFRC2013_mirror` as a mirror reg
- Fix: store the type (mirror vs bridge) explicitly in a companion environment (`.reglist_mirror_cache`) at `add_reglist()` time; `allreg_dataframe()` uses this metadata for in-memory entries instead of pattern-matching the key
- Also tightens the disk-file regex to require a file extension, so it only matches `*mirror.list` / `*mirror.rds` as before

## Test plan

- [ ] Added regression test: bridge reg with `_mirror`-suffixed sample brain name is correctly classified as `bridge` not `mirror`
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)